### PR TITLE
Add missing \ to French strings.xml

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -107,7 +107,7 @@
     <string name="show_pokestops">Afficher les Pokestops</string>
     <string name="show_pokestop_desc">Activer/Désactiver les Pokestops sur la carte</string>
     <string name="lock_gps">Scan via GPS</string>
-    <string name="lock_gps_desc">Scan en fonction de votre localisation plutot qu'en fonction du point du vue</string>
+    <string name="lock_gps_desc">Scan en fonction de votre localisation plutot qu\'en fonction du point du vue</string>
 
     <string name="gyms_cleared">Arènes effacées</string>
     <string name="pokestops_cleared">Pokestops effacés</string>


### PR DESCRIPTION
Build was failing because a string in french strings.xml had an unescaped apostrophe.
